### PR TITLE
Subscriptions support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,6 @@ STRIPE_TEST_SECRET_KEY=
 
 # A Stripe account that is already connected to the account above.
 STRIPE_CONNECTED_ACCOUNT_ID=
+
+# A stripe test plan id is necessary to run tests related to subscriptions.
+STRIPE_TEST_PLAN_ID=

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stripe-stateful-mock",
-  "version": "0.0.9",
+  "version": "0.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "prepublishOnly": "npm run clean && npm run build && npm run lint && npm run test",
     "run": "LOG_LEVEL=info node dist/index.js",
     "run:debug": "LOG_LEVEL=debug node dist/index.js",
-    "test": "LOG_LEVEL=silent mocha --recursive --timeout 5000 --require ts-node/register --require ./test/requireDotEnv.ts --exit \"test/**/*.ts\"",
+    "test": "npm run lint && LOG_LEVEL=silent mocha --recursive --timeout 5000 --require ts-node/register --require ./test/requireDotEnv.ts --exit \"test/**/*.ts\"",
     "test:debug": "LOG_LEVEL=trace mocha --recursive --timeout 5000 --require ts-node/register --require ./test/requireDotEnv.ts --exit \"test/**/*.ts\""
   },
   "repository": {

--- a/server.js
+++ b/server.js
@@ -1,0 +1,1 @@
+module.exports = require("./dist/server.js")

--- a/server.js
+++ b/server.js
@@ -1,1 +1,13 @@
+/**
+ * This is a utility alias.
+ *
+ * This allows users of the library via `npm install`
+ * to import it as `require('stripe-stateful-mock/server)`
+ *
+ * If you import `stripe-stateful-mock` directly it will listen
+ * on port 8000.
+ *
+ * If you import the server you can listen on any port you
+ * want, which is super useful for integration tests & CI.
+ */
 module.exports = require("./dist/server.js")

--- a/src/api/customers.ts
+++ b/src/api/customers.ts
@@ -169,6 +169,12 @@ export namespace customers {
         return customer;
     }
 
+    export function addSubscription(accountId: string, customerId: string, subscription: stripe.subscriptions.ISubscription): void {
+        const customer = retrieve(accountId, customerId, "customer")
+        customer.subscriptions.data.push(subscription)
+        customer.subscriptions.total_count++
+    }
+
     export function createCard(accountId: string, customerOrId: string | stripe.customers.ICustomer, params: stripe.customers.ICustomerSourceCreationOptions): stripe.cards.ICard {
         log.debug("customers.createCard", accountId, customerOrId, params);
 

--- a/src/api/subscriptions.ts
+++ b/src/api/subscriptions.ts
@@ -52,6 +52,12 @@ export namespace subscriptions {
         const now = Math.floor((Date.now() / 1000))
         const nextMonth = new Date()
         nextMonth.setMonth(nextMonth.getMonth() + 1);
+
+        let paramQuantity = +params.quantity
+        if (!params.quantity && params.items.length === 1) {
+            paramQuantity = +params.items[0].quantity
+        }
+
         const subscription: stripe.subscriptions.ISubscription = {
             id: subscriptionId,
             object: "subscription",
@@ -85,7 +91,7 @@ export namespace subscriptions {
             livemode: false,
             metadata: stringifyMetadata(params.metadata),
             plan: createPlanObj(plan),
-            quantity: +params.quantity || 1,
+            quantity: paramQuantity || 1,
             start: Math.floor(Date.now() / 1000),
             start_date: Math.floor(Date.now() / 1000),
             status: 'active',

--- a/src/api/subscriptions.ts
+++ b/src/api/subscriptions.ts
@@ -1,0 +1,221 @@
+import * as stripe from "stripe";
+import log = require("loglevel");
+import {AccountData} from "./AccountData"
+import { StripeError } from "./StripeError";
+import { applyListOptions, generateId, stringifyMetadata } from "./utils";
+import { customers } from "./customers"
+
+const FILE_START = Date.now()
+
+export namespace subscriptions {
+    const accountSubscriptions = new AccountData<
+        stripe.subscriptions.ISubscription
+    >();
+
+    export function create(
+        accountId: string,
+        params: stripe.subscriptions.ISubscriptionCreationOptions
+    ): stripe.subscriptions.ISubscription {
+        log.debug("subscriptions.create", accountId, params)
+
+        const paramId = (params as any).id
+        if (paramId && accountSubscriptions.contains(accountId, paramId)) {
+            throw new StripeError(400, {
+                code: "resource_already_exists",
+                doc_url: "https://stripe.com/docs/error-codes/resource-already-exists",
+                message: "Subscription already exists.",
+                type: "invalid_request_error"
+            });
+        }
+
+        let default_source
+        let paramsDefaultSource = params.default_source
+        if (paramsDefaultSource && typeof paramsDefaultSource !== 'string') {
+            const customer = params.customer
+            const card = customers.createCard(accountId, customer, {
+                source: paramsDefaultSource
+            })
+            default_source = card.id
+        } else if (typeof paramsDefaultSource === 'string') {
+            default_source = paramsDefaultSource
+        }
+
+        let plan = params.plan
+        if (!plan) {
+            plan = params.items[0].plan
+        }
+
+        const subscriptionId = paramId || `sub_${generateId(14)}`
+        const now = Math.floor((Date.now() / 1000))
+        const nextMonth = new Date()
+        nextMonth.setMonth(nextMonth.getMonth() + 1);
+        const subscription: stripe.subscriptions.ISubscription = {
+            id: subscriptionId,
+            object: "subscription",
+            application_fee_percent: +params.application_fee_percent || null,
+            billing: params.billing || "charge_automatically",
+            collection_method: params.billing || "charge_automatically",
+            billing_cycle_anchor: +params.billing_cycle_anchor || now,
+            billing_thresholds: null,
+            cancel_at: null,
+            cancel_at_period_end: false,
+            canceled_at: null,
+            created: now,
+            current_period_end: Math.floor(nextMonth.getTime() / 1000),
+            /** Hard coded to assume month long subscriptions */
+            current_period_start: now,
+            customer: params.customer,
+            days_until_due: params.days_until_due || null,
+            default_payment_method: null,
+            default_source: default_source || null,
+            /*default_tax_rates*/
+            discount: null,
+            ended_at: null,
+            items: {
+                object: "list",
+                total_count: params.items ? params.items.length : 0,
+                data: [],
+                has_more: false,
+                url: `/v1/subscription_items?subscription=${subscriptionId}`
+            },
+            latest_invoice: `in_${generateId(14)}`,
+            livemode: false,
+            metadata: stringifyMetadata(params.metadata),
+            plan: createPlanObj(plan),
+            quantity: params.quantity || 1,
+            start: Math.floor(Date.now() / 1000),
+            start_date: Math.floor(Date.now() / 1000),
+            status: 'active',
+            tax_percent: params.tax_percent || null,
+            trial_end: null,
+            trial_start: null
+        }
+
+        if (params.items) {
+            for (const item of params.items) {
+                subscription.items.data.push(
+                    createItem(item, subscription)
+                )
+            }
+        }
+
+        accountSubscriptions.put(accountId, subscription);
+        customers.addSubscription(
+            accountId,
+            typeof subscription.customer === 'string' ?
+                subscription.customer : subscription.customer.id,
+            subscription
+        )
+
+        return subscription
+    }
+
+    function createPlanObj(planName: string): stripe.plans.IPlan {
+        const plan: stripe.plans.IPlan = {
+            id: planName,
+            object: 'plan',
+            active: true,
+            aggregate_usage: null,
+            amount: 10 * 100,
+            billing_scheme: 'per_unit',
+            created: Math.floor(FILE_START / 1000),
+            currency: 'usd',
+            interval: 'month',
+            interval_count: 1,
+            livemode: false,
+            metadata: {},
+            nickname: null,
+            product: `prod_${planName.substr(5)}`,
+            tiers: null,
+            tiers_mode: null,
+            transform_usage: null,
+            trial_period_days: null,
+            usage_type: 'licensed'
+        }
+
+        return plan
+    }
+
+    export function createItem(
+        item: stripe.subscriptions.ISubscriptionCreationItem,
+        subscription: stripe.subscriptions.ISubscription
+    ): stripe.subscriptionItems.ISubscriptionItem {
+        const paramId = (item as any).id
+        const subItemId = paramId || `si_${generateId(14)}`
+
+        const subscriptionItem: stripe.subscriptionItems.ISubscriptionItem = {
+            object: 'subscription_item',
+            id: subItemId,
+            billing_thresholds: null,
+            created: Math.floor(Date.now() / 1000),
+            metadata: stringifyMetadata(item.metadata),
+            plan: createPlanObj(item.plan),
+            subscription: subscription.id
+        }
+
+        return subscriptionItem
+    }
+
+    export function update(
+        accountId: string, subscriptionId: string, params: stripe.subscriptions.ISubscriptionUpdateOptions
+    ): stripe.subscriptions.ISubscription {
+        log.debug("subscriptions.update", accountId, subscriptionId, params);
+
+        const subscription = retrieve(accountId, subscriptionId, "id");
+
+        if (params.items) {
+            for (let i = 0; i < params.items.length; i++) {
+                subscription.items.data[i].quantity =
+                    params.items[i].quantity
+            }
+        }
+
+        return subscription;
+    }
+
+    export function retrieve(
+        accountId: string,
+        subscriptionId: string,
+        paramName: string
+    ): stripe.subscriptions.ISubscription {
+        log.debug("subscriptions.retrieve")
+
+        const subscription = accountSubscriptions.get(
+            accountId, subscriptionId
+        );
+        if (!subscription) {
+            throw new StripeError(404, {
+                code: "resource_missing",
+                doc_url: "https://stripe.com/docs/error-codes/resource-missing",
+                message: `No such subscription: ${subscriptionId}`,
+                param: paramName,
+                type: "invalid_request_error"
+            })
+        }
+        return subscription;
+    }
+
+    export function list(
+        accountId: string,
+        params: stripe.subscriptions.ISubscriptionListOptions
+    ): stripe.IList<stripe.subscriptions.ISubscription> {
+        let data = accountSubscriptions.getAll(accountId)
+        if (params.customer) {
+            data = data.filter(d => {
+                if (typeof d.customer === 'string') {
+                    return d.customer === params.customer
+                } else {
+                    return d.customer.id === params.customer
+                }
+            })
+        }
+
+        return applyListOptions(data, params, (id, paramName) => {
+            return retrieve(accountId, id, paramName)
+        })
+    }
+
+    /**
+     * TODO: export function update()
+     */
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,35 +1,12 @@
-import express from "express";
-import bodyParser from "body-parser";
 import log = require("loglevel");
-import {routes} from "./routes";
-import {StripeError} from "./api/StripeError";
-import {idempotencyRoute} from "./api/idempotency";
-import {auth} from "./api/auth";
+
+import { createApp } from "./server";
 
 if (process.env.hasOwnProperty("LOG_LEVEL")) {
     log.setLevel(process.env["LOG_LEVEL"] as any);
 }
 
-const app = express();
-
-app.use(bodyParser.urlencoded({ extended: true }));
-app.use(auth.authRoute);
-app.use(idempotencyRoute);
-app.use("/", routes);
-
-// Error handling comes last.
-app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
-    if (err instanceof StripeError) {
-        res.status(err.statusCode).send({error: err.error});
-        return;
-    }
-
-    log.error("Unexpected error:", err.stack);
-    res.status(500).send({
-        message: "Unexpected error: " + err.message,
-        stack: err.stack
-    });
-});
+const app = createApp();
 
 const port = process.env["PORT"] || 8000;
 app.listen(+port, () => {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -103,10 +103,7 @@ routes.get("/v1/subscriptions/:id", (req, res) => {
     return res.status(200).json(subscription);
 });
 
-routes.post("/v1/subscriptions/:id", (req, res) => {
-    const subscription = subscriptions.update(getRequestAccountId(req), req.params.id, req.body);
-    return res.status(200).json(subscription);
-})
+// TODO: routes.post("/v1/subscriptions/:id")
 
 routes.get("/v1/subscription_items", (req, res) => {
     const subscriptionItemList = subscriptions.listItem(getRequestAccountId(req), req.query);
@@ -165,8 +162,6 @@ routes.get("/v1/refunds/:id", (req, res) => {
     const refund = refunds.retrieve(getRequestAccountId(req), req.params.id, "id");
     return res.status(200).json(refund);
 });
-
-// TODO: add /v1/subscriptions
 
 routes.all('*', (req, res) => {
     return res.status(404).json({

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -108,6 +108,22 @@ routes.post("/v1/subscriptions/:id", (req, res) => {
     return res.status(200).json(subscription);
 })
 
+routes.get("/v1/subscription_items", (req, res) => {
+    const subscriptionItemList = subscriptions.listItem(getRequestAccountId(req), req.query);
+    return res.status(200).json(subscriptionItemList);
+});
+
+routes.get("/v1/subscription_items/:id", (req, res) => {
+    const subscriptionItem = subscriptions.retrieveItem(getRequestAccountId(req), req.params.id, "id");
+    return res.status(200).json(subscriptionItem);
+});
+
+routes.post("/v1/subscription_items/:id", (req, res) => {
+    const subscriptionItem = subscriptions.updateItem(getRequestAccountId(req), req.params.id, req.body);
+    return res.status(200).json(subscriptionItem);
+});
+
+
 // Old API.
 routes.get("/v1/customers/:customerId/cards/:cardId", (req, res) => {
     const card = customers.retrieveCard(getRequestAccountId(req), req.params.customerId, req.params.cardId, "card");

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -5,6 +5,7 @@ import {charges} from "./api/charges";
 import {customers} from "./api/customers";
 import {disputes} from "./api/disputes";
 import {refunds} from "./api/refunds";
+import {subscriptions} from "./api/subscriptions"
 
 const routes = express.Router();
 
@@ -87,6 +88,26 @@ routes.post("/v1/customers/:id", (req, res) => {
     return res.status(200).json(customer);
 });
 
+routes.post("/v1/subscriptions", (req, res) => {
+    const subscription = subscriptions.create(getRequestAccountId(req), req.body);
+    return res.status(200).json(subscription);
+});
+
+routes.get("/v1/subscriptions", (req, res) => {
+    const subscriptionList = subscriptions.list(getRequestAccountId(req), req.query);
+    return res.status(200).json(subscriptionList);
+});
+
+routes.get("/v1/subscriptions/:id", (req, res) => {
+    const subscription = subscriptions.retrieve(getRequestAccountId(req), req.params.id, "id");
+    return res.status(200).json(subscription);
+});
+
+routes.post("/v1/subscriptions/:id", (req, res) => {
+    const subscription = subscriptions.update(getRequestAccountId(req), req.params.id, req.body);
+    return res.status(200).json(subscription);
+})
+
 // Old API.
 routes.get("/v1/customers/:customerId/cards/:cardId", (req, res) => {
     const card = customers.retrieveCard(getRequestAccountId(req), req.params.customerId, req.params.cardId, "card");
@@ -128,6 +149,17 @@ routes.get("/v1/refunds/:id", (req, res) => {
     const refund = refunds.retrieve(getRequestAccountId(req), req.params.id, "id");
     return res.status(200).json(refund);
 });
+
+// TODO: add /v1/subscriptions
+
+routes.all('*', (req, res) => {
+    return res.status(404).json({
+        error: {
+            type: 'invalid_request_error',
+            message: '404 Not Found, ' + req.path
+        }
+    })
+})
 
 export function getRequestAccountId(req: express.Request): string {
     const connectAccountId = req.header("stripe-account");

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,36 @@
+import express from "express";
+import bodyParser from "body-parser";
+import log = require("loglevel");
+import {routes} from "./routes";
+import {StripeError} from "./api/StripeError";
+import {idempotencyRoute} from "./api/idempotency";
+import {auth} from "./api/auth";
+
+if (process.env.hasOwnProperty("LOG_LEVEL")) {
+    log.setLevel(process.env["LOG_LEVEL"] as any);
+}
+
+export function createApp(): express.Application {
+    const app = express();
+
+    app.use(bodyParser.urlencoded({ extended: true }));
+    app.use(auth.authRoute);
+    app.use(idempotencyRoute);
+    app.use("/", routes);
+
+    // Error handling comes last.
+    app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
+        if (err instanceof StripeError) {
+            res.status(err.statusCode).send({error: err.error});
+            return;
+        }
+
+        log.error("Unexpected error:", err.stack);
+        res.status(500).send({
+            message: "Unexpected error: " + err.message,
+            stack: err.stack
+        });
+    });
+
+    return app;
+}

--- a/test/stripeAssert.ts
+++ b/test/stripeAssert.ts
@@ -38,6 +38,7 @@ export type ComparableStripeObject = Error
     | Stripe.charges.ICharge
     | Stripe.customers.ICustomer
     | Stripe.subscriptions.ISubscription
+    | Stripe.subscriptionItems.ISubscriptionItem
     | Stripe.disputes.IDispute
     | Stripe.paymentIntents.IPaymentIntent
     | Stripe.refunds.IRefund;
@@ -71,6 +72,9 @@ export function assertObjectsAreBasicallyEqual(actual: ComparableStripeObject, e
             break;
         case "subscription":
             assertSubscriptionsAreBasicallyEqual(actual as Stripe.subscriptions.ISubscription, expected as Stripe.subscriptions.ISubscription, message);
+            break;
+        case "subscription_item":
+            assertSubscriptionItemsAreBasicallyEqual(actual as Stripe.subscriptionItems.ISubscriptionItem, expected as Stripe.subscriptionItems.ISubscriptionItem, message);
             break;
         case "dispute":
             assertDisputesAreBasicallyEqual(actual as Stripe.disputes.IDispute, expected as Stripe.disputes.IDispute, message);
@@ -153,19 +157,17 @@ export function assertSubscriptionsAreBasicallyEqual(
     expected: Stripe.subscriptions.ISubscription,
     message?: string
 ): void {
-    assertEqualOnKeys(
-        actual, expected, [
-            "object", "application_fee_percent", "billing",
-            "collection_method",
-            "billing_thresholds", "cancel_at", "cancel_at_period_end",
-            "canceled_at",
-            "days_until_due", "default_payment_method",
-            "default_source", "discount", "ended_at",
-            "livemode", "metadata",
-            "quantity", "status",
-            "tax_percent", "trial_end", "trial_start"
-        ], message
-    )
+    assertEqualOnKeys(actual, expected, [
+        "object", "application_fee_percent", "billing",
+        "collection_method",
+        "billing_thresholds", "cancel_at", "cancel_at_period_end",
+        "canceled_at",
+        "days_until_due", "default_payment_method",
+        "default_source", "discount", "ended_at",
+        "livemode", "metadata",
+        "quantity", "status",
+        "tax_percent", "trial_end", "trial_start"
+    ], message)
     assertSetOrUnsetOnKeys(actual, expected, [
         "id", "items", "plan", "billing_cycle_anchor", "created",
         "current_period_end", "current_period_start", "customer",
@@ -177,7 +179,35 @@ export function assertSubscriptionsAreBasicallyEqual(
     for (let itemIx = 0; itemIx < expected.items.total_count; itemIx++) {
         chai.assert.equal(actual.items.data[itemIx].object, "subscription_item")
         chai.assert.equal(expected.items.data[itemIx].object, "subscription_item")
+        chai.assert.equal(
+            actual.items.data[itemIx].subscription, actual.id
+        )
+        chai.assert.equal(
+            expected.items.data[itemIx].subscription, expected.id
+        )
+
+        assertSubscriptionItemsAreBasicallyEqual(
+            actual.items.data[itemIx],
+            expected.items.data[itemIx],
+            message
+        )
     }
+    chai.assert.ok(actual.plan.id)
+    chai.assert.ok(expected.plan.id)
+}
+
+export function assertSubscriptionItemsAreBasicallyEqual(
+    actual: Stripe.subscriptionItems.ISubscriptionItem,
+    expected: Stripe.subscriptionItems.ISubscriptionItem,
+    message: string
+): void {
+    assertEqualOnKeys(actual, expected, [
+        "object", "billing_thresholds", "metadata", "quantity"
+    ], message)
+    assertSetOrUnsetOnKeys(actual, expected, [
+        "created", "subscription", "plan"
+    ], message)
+
     chai.assert.ok(actual.plan.id)
     chai.assert.ok(expected.plan.id)
 }

--- a/test/subscriptions.ts
+++ b/test/subscriptions.ts
@@ -93,7 +93,15 @@ describe("subscriptions", function () {
                 5
             );
 
-            return [updated, subscriptionGet]
+            const customerGet = await stripeClient.customers
+                .retrieve(customer.id)
+
+            chai.assert.equal(
+                customerGet.subscriptions.data[0].quantity,
+                5
+            );
+
+            return [updated, subscriptionGet, customerGet]
         }
     ))
 
@@ -107,7 +115,7 @@ describe("subscriptions", function () {
                     customer: customer.id,
                     items: [{
                         plan: TEST_PLAN,
-                        quantity: 1
+                        quantity: 2
                     }]
                 })
 
@@ -118,6 +126,10 @@ describe("subscriptions", function () {
             chai.assert.equal(
                 customerGet.subscriptions.data[0].id,
                 subscription.id
+            );
+            chai.assert.equal(
+                customerGet.subscriptions.data[0].quantity,
+                2
             );
 
             return [customerGet]

--- a/test/subscriptions.ts
+++ b/test/subscriptions.ts
@@ -1,0 +1,104 @@
+import * as chai from "chai";
+import {buildStripeParityTest} from "./buildStripeParityTest";
+import { getLocalStripeClient } from "./stripeUtils"
+
+describe("subscriptions", function () {
+
+    const localStripeClient = getLocalStripeClient()
+    const TEST_PLAN = process.env.STRIPE_TEST_PLAN_ID
+    if (!TEST_PLAN) {
+        throw new Error('STRIPE_TEST_PLAN_ID is not set...')
+    }
+
+    this.timeout(30 * 1000);
+
+    it.skip("supports basic creation with no params", buildStripeParityTest(
+        async (stripeClient) => {
+            const customer = await stripeClient
+                .customers.create({
+                    source: "tok_visa"
+                })
+
+            const subscription = await stripeClient
+                .subscriptions.create({
+                    customer: customer.id,
+                    items: [{
+                        plan: TEST_PLAN,
+                        quantity: 1
+                    }]
+                })
+            const subscriptionGet = await stripeClient
+                .subscriptions.retrieve(subscription.id);
+
+            chai.assert.equal(subscriptionGet.customer, customer.id);
+            chai.assert.equal(
+                subscriptionGet.plan.id,
+                subscriptionGet.items.data[0].plan.id
+            );
+            chai.assert.equal(
+                subscriptionGet.id,
+                subscriptionGet.items.data[0].subscription
+            )
+
+            return [subscription, subscriptionGet];
+        }
+    ))
+
+    it("supports updating the quantity", buildStripeParityTest(
+        async (stripeClient) => {
+            const customer = await stripeClient.customers.create({
+                source: "tok_visa"
+            })
+            console.log('attempt create')
+            const subscription = await stripeClient.subscriptions
+                .create({
+                    customer: customer.id,
+                    items: [{
+                        plan: TEST_PLAN,
+                        quantity: 1
+                    }]
+                })
+
+            console.log('attempt update')
+            const updated = await stripeClient.subscriptions
+                .update(subscription.id, {
+                    items: [{
+                        quantity: 5
+                    }]
+                })
+
+            const subscriptionGet = await stripeClient.subscriptions
+                .retrieve(subscription.id);
+
+            chai.assert.equal(subscriptionGet.items.data[0].quantity, 5);
+
+            return [updated, subscriptionGet]
+        }
+    ))
+
+    it("supports fetching subscriptions from customer", buildStripeParityTest(
+        async (stripeClient) => {
+            const customer = await stripeClient.customers.create({
+                source: "tok_visa"
+            })
+            const subscription = await stripeClient.subscriptions
+                .create({
+                    customer: customer.id,
+                    items: [{
+                        plan: TEST_PLAN,
+                        quantity: 1
+                    }]
+                })
+
+            const customerGet = await stripeClient.customers
+                .retrieve(customer.id);
+
+            console.log("customerGet", customerGet);
+
+            chai.assert.equal(customerGet.subscriptions.total_count, 1)
+            chai.assert.equal(customerGet.subscriptions.data[0].id, subscription.id);
+
+            return [customerGet]
+        }
+    ))
+})


### PR DESCRIPTION
This PR implements a bunch of the logic necessary to use the stripe.subscriptions api

It’s not complete ( update is missing a bunch of logic ).

But it’s sufficient for me to test my subscriptions logic in my app.